### PR TITLE
fix(api): fix vercel cache for prisma generated

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
### TL;DR 
Updated the build script in `package.json` to include `prisma generate` before running `next build`. Kudos to https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/vercel-caching-issue

### What changed?
Modified the build script in the `package.json` file from `next build` to `prisma generate && next build`.

### How to test?
Run the build script using `npm run build` and ensure that Prisma client is generated before the Next.js build process is initiated.

### Why make this change?
This change ensures that the Prisma client is always up-to-date before building the Next.js application, preventing potential runtime issues related to the database schema.

---

